### PR TITLE
Add support for multiple pH sensors

### DIFF
--- a/DFRobot_PH.cpp
+++ b/DFRobot_PH.cpp
@@ -29,6 +29,51 @@
 // The start address of the pH calibration parameters stored in the EEPROM
 #define PHVALUEADDR 0    
 
+// Maps the pin (A0,A1..A11) to a number 0-11 so the address can be determined
+uint8_t mapPHPin(uint8_t phPin)
+{
+    int addressMap = 0;
+    if (phPin == A0){
+        Serial.print(" pin A0 ");
+        addressMap = 0;
+    } else if (phPin == A1){
+        Serial.print(" pin A1 ");
+        addressMap = 1;
+    } else if (phPin == A2){
+        Serial.print(" pin A2 ");
+        addressMap = 2;
+    } else if (phPin == A3){
+        Serial.print(" pin A3 ");
+        addressMap = 3;
+    } else if (phPin == A4){
+        Serial.print(" pin A4 ");
+        addressMap = 4;
+    } else if (phPin == A5){
+        Serial.print(" pin A5 ");
+        addressMap = 5;
+    } else if (phPin == A6){
+        Serial.print(" pin A6 ");
+        addressMap = 6;
+    } else if (phPin == A7){
+        Serial.print(" pin A7 ");
+        addressMap = 7;
+    } else if (phPin == A8){
+        Serial.print(" pin A8 ");
+        addressMap = 8;
+    } else if (phPin == A9){
+        Serial.print(" pin A9 ");
+        addressMap = 9;
+    } else if (phPin == A10){
+        Serial.print(" pin A10 ");
+        addressMap = 10;
+    } else if (phPin == A11){
+        Serial.print(" pin A11 ");
+        addressMap = 11;
+    }
+
+    return addressMap;
+}
+
 // Default construtor to ensure backwards compatibility
 DFRobot_PH::DFRobot_PH()
 {
@@ -40,7 +85,7 @@ DFRobot_PH::DFRobot_PH()
     // This will be 8byte per sensor and the largest arduino has 12 analogue ports
     // So let's start at address 0 and go up by 8b for each analogue port. This will use upto 96b 
     // For the EC library we will start after PH addresses
-    this->_address        = PHVALUEADDR + (sizeof(float) * 2 * EPinToAddressMap[this->_pin]);
+    this->_address        = PHVALUEADDR + (sizeof(float) * 2 * mapPHPin(this->_pin));
 
     // Buffer solution 4.0 at 25C
     this->_acidVoltage    = 2032.44;    
@@ -55,7 +100,7 @@ DFRobot_PH::DFRobot_PH()
 }
 
 // Updated construtor to allow multiple pH sensors
-DFRobot_PH::DFRobot_PH(int phPin)
+DFRobot_PH::DFRobot_PH(uint8_t phPin)
 {
     // Set the pin to the supplied value
     this->_pin            = phPin;
@@ -65,7 +110,7 @@ DFRobot_PH::DFRobot_PH(int phPin)
     // This will be 8byte per sensor and the largest arduino has 12 analogue ports
     // So let's start at address 0 and go up by 8b for each analogue port. This will use upto 96b 
     // For the EC library we will start after PH addresses
-    this->_address        = PHVALUEADDR + (sizeof(float) * 2 * EPinToAddressMap[this->_pin]);
+    this->_address        = PHVALUEADDR + (sizeof(float) * 2 * mapPHPin(this->_pin));
 
     // Buffer solution 4.0 at 25C
     this->_acidVoltage    = 2032.44;    
@@ -87,6 +132,15 @@ DFRobot_PH::~DFRobot_PH()
 // Initialiser
 void DFRobot_PH::begin()
 {
+    Serial.print("_pin:");
+    Serial.println(this->_pin);
+
+    Serial.print("mapped:");
+    Serial.println(mapPHPin(this->_pin));
+
+    Serial.print("_address:");
+    Serial.println(this->_address);
+
     // Load the neutral (pH = 7.0) voltage of the pH board from the EEPROM
     EEPROM_read(this->_address, this->_neutralVoltage);  
     Serial.print("_neutralVoltage:");

--- a/DFRobot_PH.cpp
+++ b/DFRobot_PH.cpp
@@ -40,7 +40,7 @@ DFRobot_PH::DFRobot_PH()
     // This will be 8byte per sensor and the largest arduino has 12 analogue ports
     // So let's start at address 0 and go up by 8b for each analogue port. This will use upto 96b 
     // For the EC library we will start after PH addresses
-    this->_address        = PHVALUEADDR + (sizeof(float) * 2 *  this->_pin);
+    this->_address        = PHVALUEADDR + (sizeof(float) * 2 * EPinToAddressMap[this->_pin]);
 
     // Buffer solution 4.0 at 25C
     this->_acidVoltage    = 2032.44;    
@@ -65,7 +65,7 @@ DFRobot_PH::DFRobot_PH(int phPin)
     // This will be 8byte per sensor and the largest arduino has 12 analogue ports
     // So let's start at address 0 and go up by 8b for each analogue port. This will use upto 96b 
     // For the EC library we will start after PH addresses
-    this->_address        = PHVALUEADDR + (sizeof(float) * 2 *  this->_pin);
+    this->_address        = PHVALUEADDR + (sizeof(float) * 2 * EPinToAddressMap[this->_pin]);
 
     // Buffer solution 4.0 at 25C
     this->_acidVoltage    = 2032.44;    
@@ -121,7 +121,7 @@ float DFRobot_PH::readPH(float voltage, float temperature)
     
     // Linear response y = k*x + b
     this->_phValue = slope * (voltage - 1500.0) / 3.0 + intercept;  
-    
+
     return _phValue;
 }
 

--- a/DFRobot_PH.h
+++ b/DFRobot_PH.h
@@ -23,8 +23,26 @@
 #include "WProgram.h"
 #endif
 
+#include <map>
+
 // Length of the Serial CMD buffer
 #define ReceivedBufferLength 10  
+
+/// Map from pin to a address number to be multiplied by the number of bytes offset
+static std::map<uint8_t, uint8_t> EPinToAddressMap{
+	{A0, 0}, 
+	{A1, 1}, 
+	{A2, 2}, 
+	{A3, 3}, 
+	{A4, 4}, 
+	{A5, 5}, 
+	{A6, 6}, 
+	{A7, 7}, 
+	{A8, 8}, 
+	{A9, 9}, 
+	{A10, 10}, 
+	{A11, 11}, 
+    };
 
 class DFRobot_PH
 {

--- a/DFRobot_PH.h
+++ b/DFRobot_PH.h
@@ -23,33 +23,22 @@
 #include "WProgram.h"
 #endif
 
-#include <map>
-
 // Length of the Serial CMD buffer
 #define ReceivedBufferLength 10  
 
-/// Map from pin to a address number to be multiplied by the number of bytes offset
-static std::map<uint8_t, uint8_t> EPinToAddressMap{
-	{A0, 0}, 
-	{A1, 1}, 
-	{A2, 2}, 
-	{A3, 3}, 
-	{A4, 4}, 
-	{A5, 5}, 
-	{A6, 6}, 
-	{A7, 7}, 
-	{A8, 8}, 
-	{A9, 9}, 
-	{A10, 10}, 
-	{A11, 11}, 
-    };
+/**
+ * Maps the pin (A0,A1..A11) to a number 0-11 so the address can be determined
+ * @param phPin the pin the pH sensor is attached to
+ * @return the address multiplier
+ */
+uint8_t mapPHPin(uint8_t phPin);
 
 class DFRobot_PH
 {
 public:
     // Construtors
     DFRobot_PH();
-    DFRobot_PH(int phPin);
+    DFRobot_PH(uint8_t phPin);
     
     // Destructors
     ~DFRobot_PH();
@@ -65,7 +54,7 @@ public:
     float   readPH(float voltage, float temperature); 
 
 private:
-    int _pin;
+    uint8_t _pin;
     int _address;
     float  _phValue;
     float  _acidVoltage;

--- a/DFRobot_PH.h
+++ b/DFRobot_PH.h
@@ -46,6 +46,8 @@ public:
     float   readPH(float voltage, float temperature); 
 
 private:
+    int _pin;
+    int _address;
     float  _phValue;
     float  _acidVoltage;
     float  _neutralVoltage;

--- a/DFRobot_PH.h
+++ b/DFRobot_PH.h
@@ -8,6 +8,10 @@
  *
  * version  V1.0
  * date  2018-04
+ * 
+ * version  V1.1
+ * date  2020-04
+ * Changes the memory addressing to allow multiple PH sensors
  */
 
 #ifndef _DFROBOT_PH_H_
@@ -24,12 +28,22 @@
 class DFRobot_PH
 {
 public:
+    // Construtors
     DFRobot_PH();
+    DFRobot_PH(int phPin);
+    
+    // Destructors
     ~DFRobot_PH();
-    void    calibration(float voltage, float temperature,char* cmd);  //calibration by Serial CMD
+    
+    // Initialization
+    void    begin();   
+    
+    // Calibration by Serial CMD
+    void    calibration(float voltage, float temperature, char* cmd);  
     void    calibration(float voltage, float temperature);
-    float   readPH(float voltage, float temperature); // voltage to pH value, with temperature compensation
-    void    begin();   //initialization
+    
+    // Voltage to pH value, with temperature compensation
+    float   readPH(float voltage, float temperature); 
 
 private:
     float  _phValue;
@@ -38,14 +52,18 @@ private:
     float  _voltage;
     float  _temperature;
 
-    char   _cmdReceivedBuffer[ReceivedBufferLength];  //store the Serial CMD
+    // Store the Serial CMD
+    char   _cmdReceivedBuffer[ReceivedBufferLength];  
     byte   _cmdReceivedBufferIndex;
 
 private:
+    // Calibration process, wirte key parameters to EEPROM
+    void    phCalibration(byte mode); 
+    
     boolean cmdSerialDataAvailable();
-    void    phCalibration(byte mode); // calibration process, wirte key parameters to EEPROM
-    byte    cmdParse(const char* cmd);
+        
     byte    cmdParse();
+    byte    cmdParse(const char* cmd);
 };
 
 #endif

--- a/DFRobot_PH.h
+++ b/DFRobot_PH.h
@@ -23,7 +23,8 @@
 #include "WProgram.h"
 #endif
 
-#define ReceivedBufferLength 10  //length of the Serial CMD buffer
+// Length of the Serial CMD buffer
+#define ReceivedBufferLength 10  
 
 class DFRobot_PH
 {

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ DFRobot_PH(int phPin);
 void begin();
 
 /*
- * @brief Convert voltage to PH with temperature compensation
+ * @brief Convert voltage to PH
  *
  * @param voltage     : Voltage value
  *        temperature : Ambient temperature

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 ## DFRobot_PH Library
 ---------------------------------------------------------
 This is the sample code for Gravity: Analog pH Sensor / Meter Kit V2, SKU:SEN0161-V2
+
+WARNING: There is no temperature compensation implemented in this library.
+         Although you can provide the temperature it is not used.
+
 ## Table of Contents
 
 * [Methods](#methods)
@@ -13,6 +17,12 @@ This is the sample code for Gravity: Analog pH Sensor / Meter Kit V2, SKU:SEN016
 ## Methods
 
 ```C++
+/*
+ * @brief The new optional constructor to allow multiple pH sensors
+ *
+ * @param phPin: The pin of the pH sensor i.e. A0
+ */
+DFRobot_PH(int phPin);
 
 /*
  * @brief Init The Analog pH Sensor
@@ -54,6 +64,10 @@ Meag2560 |      √       |             |            |
 
 - date 2018-11-6
 - version V1.0
+    - Inital version
+- date 2020-04-18
+- version V1.1
+    - Update to allow multiple pH sensors each with their own calibration
 
 ## Credits
 


### PR DESCRIPTION
Writes the calibration for each pH sensor to it's own memory address linked to the analogue pin number. This is compatible with the pull request for the EC library