### PR TITLE
Change how buffer emptied to prevent problems entering commands

### DIFF
--- a/DFRobot_PH.cpp
+++ b/DFRobot_PH.cpp
@@ -93,13 +93,8 @@ boolean DFRobot_PH::cmdSerialDataAvailable()
     char cmdReceivedChar;
     static unsigned long cmdReceivedTimeOut = millis();
     while(Serial.available()>0){
-        if(millis() - cmdReceivedTimeOut > 500U){
-            this->_cmdReceivedBufferIndex = 0;
-            memset(this->_cmdReceivedBuffer,0,(ReceivedBufferLength));
-        }
-        cmdReceivedTimeOut = millis();
         cmdReceivedChar = Serial.read();
-        if (cmdReceivedChar == '\n' || this->_cmdReceivedBufferIndex==ReceivedBufferLength-1){
+        if (cmdReceivedChar == '\n' || cmdReceivedChar == '\r' || this->_cmdReceivedBufferIndex==ReceivedBufferLength-1){
             this->_cmdReceivedBufferIndex = 0;
             strupr(this->_cmdReceivedBuffer);
             return true;
@@ -121,6 +116,7 @@ byte DFRobot_PH::cmdParse(const char* cmd)
     }else if(strstr(cmd, "CALPH")  != NULL){
         modeIndex = 2;
     }
+    emptyCmdReceivedBuffer();
     return modeIndex;
 }
 
@@ -134,7 +130,14 @@ byte DFRobot_PH::cmdParse()
     }else if(strstr(this->_cmdReceivedBuffer, "CALPH")  != NULL){
         modeIndex = 2;
     }
+    emptyCmdReceivedBuffer();
     return modeIndex;
+}
+
+void DFRobot_PH::emptyCmdReceivedBuffer()
+{
+  this->_cmdReceivedBufferIndex = 0;
+  memset(this->_cmdReceivedBuffer,0,(ReceivedBufferLength));
 }
 
 void DFRobot_PH::phCalibration(byte mode)

--- a/DFRobot_PH.h
+++ b/DFRobot_PH.h
@@ -46,6 +46,7 @@ private:
     void    phCalibration(byte mode); // calibration process, wirte key parameters to EEPROM
     byte    cmdParse(const char* cmd);
     byte    cmdParse();
+    void    emptyCmdReceivedBuffer();
 };
 
 #endif


### PR DESCRIPTION
I'm using the Gravity: Arduino Shield for Raspberry Pi B+/2B/3B/3B+/4B (https://www.dfrobot.com/product-1211.html) on a headless Raspberry Pi, so need to interact with the Arduino serial terminal using screen and connecting from an OSX terminal.

The current code to read in commands relies on a timeout that doesn't seem to work (it empties the buffer at arbitrary points), and also doesn't respect the carriage return that the OSX terminal sends when the Enter key is pressed.

This PR generalises the code so that it should work from any terminal.