### PR TITLE
Added strupr function

### DIFF
--- a/DFRobot_PH.cpp
+++ b/DFRobot_PH.cpp
@@ -25,6 +25,13 @@
 
 #define PHVALUEADDR 0x00    //the start address of the pH calibration parameters stored in the EEPROM
 
+char* strupr(char *p){
+    while(*p){
+        *p=toupper(*p);
+        p++;
+    }
+    return p;
+}
 
 DFRobot_PH::DFRobot_PH()
 {


### PR DESCRIPTION
#6
strupr isn't part of the ANSI Standards and also isn't supported by the DFRobot FireBeetle ESP8266.
This little function should fix for the FireBeetle
Credit to Sepahrad @ [ToolBox Forum](https://www.toolbox.com/tech/programming/question/strupr-and-strlwr-are-not-working-073113/)